### PR TITLE
Do not register plugin from stoq-plugins option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,15 @@
-version: 2
+version: 2.1
 workflows:
-  version: 2
   test:
     jobs:
       - test
 
+orbs:
+  python: circleci/python@0.2.1
+
 jobs:
   test:
-    docker:
-        - image: circleci/python:3.5.7
+    executor: python/default
 
     steps:
       - checkout

--- a/pytest_stoq/stoq.py
+++ b/pytest_stoq/stoq.py
@@ -55,7 +55,6 @@ def _setup_test_environment(request):
 
     manager = get_plugin_manager()
     for plugin_name in plugin_config['extra_plugins']:
-        _register_plugin(plugin_name)
         with stoqlib.api.new_store() as store:
             manager.install_plugin(store, plugin_name)
         manager.activate_plugin(plugin_name)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-stoq",
-    version="0.7.1",
+    version="0.7.2",
     author="Stoq Team",
     author_email="stoq-devel@async.com.br",
     maintainer="Stoq Team",


### PR DESCRIPTION
Fix installing plugins that doesn't follow the naming convention
stoq<plugin_name>.

Related to: https://gitlab.com/stoqtech/private/stoq-server/-/issues/153